### PR TITLE
create active and inactive classes for psk-button-link

### DIFF
--- a/src/components/psk-button-link/psk-button-link.css
+++ b/src/components/psk-button-link/psk-button-link.css
@@ -25,11 +25,17 @@
 
 .xlIcon .fa {
     font-size: 35px;
-    color: #cecece;
 }
 
 .xxlIcon .fa {
     font-size: 40px;
+}
+
+.xlIcon.inactive .fa, .xxlIcon.inactive .fa {
+    color: #cecece;
+}
+
+.xlIcon.active .fa, .xxlIcon.active .fa {
     color: #00345B;
 }
 


### PR DESCRIPTION
This update is necessary to have a better control over the colors of buttons on drug details screen. 

Currently, the big buttons have always blue icons. Smaller buttons have grey buttons. 

This update allows to display grey icon also in the big button.

This pull request is a pre-requisite for correct displaying active/inactive SmPC button on the drug details screen.